### PR TITLE
Remove digest warning when the function is inlined

### DIFF
--- a/goroutine.go
+++ b/goroutine.go
@@ -78,11 +78,6 @@ func (g *Goroutine) AddLine(l string) {
 
 		if strings.HasPrefix(l, "\t") {
 			parts := strings.Split(l, " ")
-			if len(parts) != 2 {
-				fmt.Println("ignored one line for digest")
-				return
-			}
-
 			fl := strings.TrimSpace(parts[0])
 
 			h := md5.New()


### PR DESCRIPTION
When a function is inlined in goroutine dump and load by `goroutine-inspect`, a warning message will be output as following

```
ignored one line for digest
```

<img width="1440" alt="Screen Shot 2021-12-05 at 15 53 02" src="https://user-images.githubusercontent.com/1527315/144738461-d3d89a87-fe45-41dd-b444-f204d4e9d461.png">

This PR removes this warning message, since when calculating the hash of stack trace, the inlined function has the same signature, and taking it into account doesn't affect the `dedup` result. Rmove this warning message makes the load procedure more clean.


